### PR TITLE
Fix LinkedIn job listing selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
   <br> <br>
   If you are using Windows, click on `windows-setup.bat` available in the `/setup` folder, this will install the latest chromedriver automatically.
 6. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
-7. **Note**: Recent updates changed how job cards are detected. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the class selector `li.scaffold-layout__list-item`. Older dynamic `emberXXX` IDs are no longer used.
+7. **Note**: Recent updates changed how job cards are detected. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the selector `div.scaffold-layout__list ul > li.scaffold-layout__list-item`. Older dynamic `emberXXX` IDs are no longer used.
 
 [back to index](#-content)
 
 <br>
 
 ## ❓ Troubleshooting
-If you encounter a "Failed to find Job listings! In Applier" message, make sure you are using an up-to-date version. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the generic `li.scaffold-layout__list-item` selector when locating job cards.
+If you encounter a "Failed to find Job listings! In Applier" message, make sure you are using an up-to-date version. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the selector `div.scaffold-layout__list ul > li.scaffold-layout__list-item` when locating job cards.
 
 
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ Click on above image to watch the demo or use this link https://youtu.be/gMbB1fW
   <br> <br>
   If you are using Windows, click on `windows-setup.bat` available in the `/setup` folder, this will install the latest chromedriver automatically.
 6. If you have questions or need help setting it up or to talk in general, join the github server: https://discord.gg/fFp7uUzWCY
+7. **Note**: Recent updates changed how job cards are detected. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the class selector `li.scaffold-layout__list-item`. Older dynamic `emberXXX` IDs are no longer used.
 
 [back to index](#-content)
 
 <br>
+
+## ❓ Troubleshooting
+If you encounter a "Failed to find Job listings! In Applier" message, make sure you are using an up-to-date version. The bot now searches for `li[data-occludable-job-id]` elements and falls back to the generic `li.scaffold-layout__list-item` selector when locating job cards.
+
+
 
 ## 🔧 How to configure
 1. Open `personals.py` file in `/config` folder and enter your details like name, phone number, address, etc. Whatever you want to fill in your applications.

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -263,6 +263,26 @@ def get_page_info() -> tuple[WebElement | None, int | None]:
     return pagination_element, current_page
 
 
+def find_job_listings() -> list[WebElement]:
+    '''
+    Finds all job listing elements on the search result page.
+    Tries multiple selectors to remain compatible with LinkedIn layout changes.
+    '''
+    selectors = [
+        (By.CSS_SELECTOR, "li[data-occludable-job-id]"),
+        (By.CSS_SELECTOR, "li.scaffold-layout__list-item")
+    ]
+    for selector in selectors:
+        try:
+            wait.until(EC.presence_of_all_elements_located(selector))
+            listings = driver.find_elements(*selector)
+            if listings:
+                return listings
+        except Exception:
+            continue
+    raise ValueError("No job listings found")
+
+
 
 def get_job_main_details(job: WebElement, blacklisted_companies: set, rejected_jobs: set) -> tuple[str, str, str, str, str, bool]:
     '''
@@ -278,6 +298,18 @@ def get_job_main_details(job: WebElement, blacklisted_companies: set, rejected_j
     job_details_button = job.find_element(By.TAG_NAME, 'a')  # job.find_element(By.CLASS_NAME, "job-card-list__title")  # Problem in India
     scroll_to_view(driver, job_details_button, True)
     job_id = job.get_dom_attribute('data-occludable-job-id')
+    if not job_id:
+        job_id = job.get_dom_attribute('data-job-id')
+    if not job_id:
+        try:
+            job_id = job.find_element(By.CSS_SELECTOR, '[data-job-id]').get_dom_attribute('data-job-id')
+        except NoSuchElementException:
+            job_id = None
+    if not job_id:
+        href = job_details_button.get_attribute('href')
+        m = re.search(r"currentJobId=(\d+)", href or "")
+        if m:
+            job_id = m.group(1)
     title = job_details_button.text
     title = title[:title.find("\n")]
     # company = job.find_element(By.CLASS_NAME, "job-card-container__primary-description").text
@@ -863,14 +895,10 @@ def apply_to_jobs(search_terms: list[str]) -> None:
         current_count = 0
         try:
             while current_count < switch_number:
-                # Wait until job listings are loaded
-                wait.until(EC.presence_of_all_elements_located((By.XPATH, "//li[@data-occludable-job-id]")))
-
+                # Wait until job listings are loaded and collect them
+                job_listings = find_job_listings()
                 pagination_element, current_page = get_page_info()
-
-                # Find all job listings in current page
                 buffer(3)
-                job_listings = driver.find_elements(By.XPATH, "//li[@data-occludable-job-id]")  
 
             
                 for job in job_listings:
@@ -889,7 +917,10 @@ def apply_to_jobs(search_terms: list[str]) -> None:
                     except Exception as e:
                         print_lg(f'Trying to Apply to "{title} | {company}" job. Job ID: {job_id}')
 
-                    job_link = "https://www.linkedin.com/jobs/view/"+job_id
+                    if job_id:
+                        job_link = "https://www.linkedin.com/jobs/view/" + job_id
+                    else:
+                        job_link = job.find_element(By.TAG_NAME, 'a').get_attribute('href') or 'Unknown'
                     application_link = "Easy Applied"
                     date_applied = "Pending"
                     hr_link = "Unknown"

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -270,7 +270,7 @@ def find_job_listings() -> list[WebElement]:
     '''
     selectors = [
         (By.CSS_SELECTOR, "li[data-occludable-job-id]"),
-        (By.CSS_SELECTOR, "li.scaffold-layout__list-item")
+        (By.CSS_SELECTOR, "div.scaffold-layout__list ul > li.scaffold-layout__list-item")
     ]
     for selector in selectors:
         try:

--- a/tests/test_job_listings.py
+++ b/tests/test_job_listings.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+import tempfile
+import pytest
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+mock_pg = types.ModuleType('pyautogui')
+mock_pg.FAILSAFE = False
+mock_pg.alert = lambda *a, **k: None
+mock_pg.confirm = lambda *a, **k: None
+sys.modules['pyautogui'] = mock_pg
+stub = types.ModuleType('modules.open_chrome')
+stub.driver = None
+stub.wait = None
+sys.modules['modules.open_chrome'] = stub
+import importlib
+runAiBot = importlib.import_module('runAiBot')
+
+HTML = """
+<html><body>
+<div class='scaffold-layout__list'>
+<ul>
+<li class='scaffold-layout__list-item' data-occludable-job-id='1'><a href='#'>Job 1</a></li>
+<li class='scaffold-layout__list-item' data-occludable-job-id='2'><a href='#'>Job 2</a></li>
+</ul>
+</div>
+</body></html>
+"""
+
+def start_driver():
+    options = Options()
+    options.add_argument('--headless=new')
+    try:
+        driver = webdriver.Chrome(options=options)
+    except Exception:
+        pytest.skip('WebDriver not available in test environment')
+    return driver
+
+
+def test_find_job_listings(tmp_path):
+    html_file = tmp_path / 'page.html'
+    html_file.write_text(HTML)
+    driver = start_driver()
+    try:
+        runAiBot.driver = driver
+        runAiBot.wait = WebDriverWait(driver, 1)
+        driver.get(html_file.as_uri())
+        items = runAiBot.find_job_listings()
+        assert len(items) == 2
+    finally:
+        driver.quit()

--- a/tests/test_job_listings.py
+++ b/tests/test_job_listings.py
@@ -31,6 +31,17 @@ HTML = """
 </body></html>
 """
 
+HTML_NO_ATTR = """
+<html><body>
+<div class='scaffold-layout__list'>
+<ul>
+<li class='scaffold-layout__list-item'><a href='#'>Job 1</a></li>
+<li class='scaffold-layout__list-item'><a href='#'>Job 2</a></li>
+</ul>
+</div>
+</body></html>
+"""
+
 def start_driver():
     options = Options()
     options.add_argument('--headless=new')
@@ -44,6 +55,20 @@ def start_driver():
 def test_find_job_listings(tmp_path):
     html_file = tmp_path / 'page.html'
     html_file.write_text(HTML)
+    driver = start_driver()
+    try:
+        runAiBot.driver = driver
+        runAiBot.wait = WebDriverWait(driver, 1)
+        driver.get(html_file.as_uri())
+        items = runAiBot.find_job_listings()
+        assert len(items) == 2
+    finally:
+        driver.quit()
+
+
+def test_find_job_listings_fallback(tmp_path):
+    html_file = tmp_path / 'page.html'
+    html_file.write_text(HTML_NO_ATTR)
     driver = start_driver()
     try:
         runAiBot.driver = driver


### PR DESCRIPTION
## Summary
- add `find_job_listings` to handle updated LinkedIn markup
- use this helper when scraping job posts
- detect job ID from multiple attributes
- add test for job listings detection
- mention selector update in README and troubleshooting section

## Testing
- `python -m py_compile runAiBot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683fb39f06348333a9884264d6d8d3a8