### PR TITLE
Add education details config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you encounter a "Failed to find Job listings! In Applier" message, make sure 
 
 
 ## 🔧 How to configure
-1. Open `personals.py` file in `/config` folder and enter your details like name, phone number, address, etc. Whatever you want to fill in your applications.
+1. Open `personals.py` file in `/config` folder and enter your details like name, phone number, address, education level, university name, etc. Whatever you want to fill in your applications.
 2. Open `questions.py` file in `/config` folder and enter your answers for application questions, configure wether you want the bot to pause before submission or pause if it can't answer unknown questions.
 3. Open `search.py` file in `/config` folder and enter your search preferences, job filters, configure the bot as per your needs (these settings decide which jobs to apply for or skip).
 4. Open `secrets.py` file in `/config` folder and enter your LinkedIn username, password to login and OpenAI API Key for generation of job tailored resumes and cover letters (This entire step is optional). If you do not provide username or password or leave them as default, it will login with saved profile in browser, if failed will ask you to login manually.

--- a/config/personals.py
+++ b/config/personals.py
@@ -1,0 +1,27 @@
+'''
+Sample personal details configuration for Auto_job-LinkedIn.
+Fill these values with your own information before running the bot.
+'''
+
+# Basic contact info
+first_name = "John"
+middle_name = ""
+last_name = "Doe"
+phone_number = "5551234567"
+current_city = ""
+street = ""
+state = ""
+zipcode = ""
+country = ""
+
+# Demographic information
+ethnicity = "Decline"
+gender = "Decline"
+disability_status = "Decline"
+veteran_status = "Decline"
+
+# Highest education attained (e.g., "Bachelor's")
+education_level = "Bachelor's"
+
+# College or university name
+university_name = "Virginia Tech"

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -1,0 +1,12 @@
+"""Example secrets configuration"""
+username = ""
+password = ""
+use_AI = False
+llm_api_url = ""
+llm_api_key = ""
+llm_model = ""
+stream_output = False
+ai_provider = "openai"
+deepseek_api_url = ""
+deepseek_api_key = ""
+deepseek_model = "deepseek-chat"

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -71,6 +71,9 @@ def validate_personals() -> None | ValueError | TypeError:
     check_string(disability_status, "disability_status", ["Yes", "No", "Decline"])
     check_string(veteran_status, "veteran_status", ["Yes", "No", "Decline"])
 
+    check_string(education_level, "education_level")
+    check_string(university_name, "university_name")
+
 
 
 from config.questions import *

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -489,14 +489,18 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     answer = prev_answer
                 elif 'gender' in label or 'sex' in label: 
                     answer = gender
-                elif 'disability' in label: 
+                elif 'disability' in label:
                     answer = disability_status
-                elif 'proficiency' in label: 
+                elif 'proficiency' in label:
                     answer = 'Professional'
+                elif any(word in label for word in ['university', 'college', 'school']):
+                    answer = university_name
+                elif 'education' in label or 'degree' in label:
+                    answer = education_level
                 # Add location handling
                 elif any(loc_word in label for loc_word in ['location', 'city', 'state', 'country']):
                     if 'country' in label:
-                        answer = country 
+                        answer = country
                     elif 'state' in label:
                         answer = state
                     elif 'city' in label:
@@ -568,8 +572,12 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
             if overwrite_previous_answers or prev_answer is None:
                 if 'citizenship' in label or 'employment eligibility' in label: answer = us_citizenship
                 elif 'veteran' in label or 'protected' in label: answer = veteran_status
-                elif 'disability' in label or 'handicapped' in label: 
+                elif 'disability' in label or 'handicapped' in label:
                     answer = disability_status
+                elif any(word in label for word in ['university', 'college', 'school']):
+                    answer = university_name
+                elif 'education' in label or 'degree' in label:
+                    answer = education_level
                 else: answer = answer_common_questions(label,answer)
                 foundOption = try_xp(radio, f".//label[normalize-space()='{answer}']", False)
                 if foundOption: 
@@ -627,6 +635,10 @@ def answer_questions(modal: WebElement, questions_list: set, work_location: str,
                     elif 'last' in label and 'first' not in label: answer = last_name
                     elif 'employer' in label: answer = recent_employer
                     else: answer = full_name
+                elif any(word in label for word in ['university', 'college', 'school']):
+                    answer = university_name
+                elif 'education' in label or 'degree' in label:
+                    answer = education_level
                 elif 'notice' in label:
                     if 'month' in label:
                         answer = notice_period_months


### PR DESCRIPTION
## Summary
- provide a default `config/personals.py` and `config/secrets.py` for tests
- add education level and university variables
- validate the new options in `validator.py`
- auto-fill university and degree questions
- mention new variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840da44f4dc83339cd61596f9b58995