### PR TITLE
Fix missing re import in helpers

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -17,6 +17,7 @@ version:    24.12.29.12.30
 
 import os
 import json
+import re
 
 from time import sleep
 from random import randint


### PR DESCRIPTION
## Summary
- add missing `re` import to `modules/helpers.py`
- run test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840f9092eec8333b9395a09a82bec69