### PR TITLE
Improve question handling for background check and work authorization

### DIFF
--- a/config/questions.py
+++ b/config/questions.py
@@ -37,6 +37,12 @@ linkedIn = "www.linkedin.com/in/mauro-gonzalez-bb5383269"       # "https://www.l
 # Valid options are: "U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident" or "Other"
 us_citizenship = "U.S. Citizen/Permanent Resident"
 
+# Are you willing to undergo a background check?
+background_check = "Yes"           # "Yes" or "No"
+
+# Are you authorized to work in the specified country?
+authorized_to_work = "Yes"         # "Yes" or "No"
+
 
 
 ## SOME ANNOYING QUESTIONS BY COMPANIES 🫠 ##

--- a/modules/validator.py
+++ b/modules/validator.py
@@ -91,6 +91,8 @@ def validate_questions() -> None | ValueError | TypeError:
     check_string(linkedIn, "linkedIn")
     check_int(desired_salary, "desired_salary")
     check_string(us_citizenship, "us_citizenship", ["U.S. Citizen/Permanent Resident", "Non-citizen allowed to work for any employer", "Non-citizen allowed to work for current employer", "Non-citizen seeking work authorization", "Canadian Citizen/Permanent Resident", "Other"])
+    check_string(background_check, "background_check", ["Yes", "No"])
+    check_string(authorized_to_work, "authorized_to_work", ["Yes", "No"])
     check_string(linkedin_headline, "linkedin_headline")
     check_int(notice_period, "notice_period")
     check_int(current_ctc, "current_ctc")

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -450,7 +450,18 @@ def upload_resume(modal: WebElement, resume: str) -> tuple[bool, str]:
 
 # Function to answer common questions for Easy Apply
 def answer_common_questions(label: str, answer: str) -> str:
-    if 'sponsorship' in label or 'visa' in label: answer = require_visa
+    label_low = label.lower()
+    if 'sponsorship' in label_low or 'visa' in label_low:
+        answer = require_visa
+    elif 'background' in label_low and 'check' in label_low:
+        answer = background_check
+    elif (
+        ('authorized' in label_low and 'work' in label_low)
+        or ('authorization' in label_low and 'work' in label_low)
+        or ('eligible' in label_low and 'work' in label_low)
+        or ('right to work' in label_low)
+    ):
+        answer = authorized_to_work
     return answer
 
 


### PR DESCRIPTION
## Summary
- store default answers to background check and work authorization questions
- validate these new config options
- detect employer questions about background checks or authorization to work

## Testing
- `python -m py_compile runAiBot.py modules/validator.py config/questions.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_b_68425ca867908333b959f3c7eca01244