### PR TITLE
Scroll to Easy Apply button before click

### DIFF
--- a/modules/clickers_and_finders.py
+++ b/modules/clickers_and_finders.py
@@ -179,5 +179,6 @@ def find_easy_apply_button(driver: WebDriver) -> WebElement | bool:
     for xp in xpaths:
         btn = try_xp(driver, xp, False)
         if btn:
+            scroll_to_view(driver, btn, True)
             return btn
     return False


### PR DESCRIPTION
## Summary
- ensure the Easy Apply button is scrolled into view before returning it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68433db8f5888333bf819c1169581565