### PR TITLE
Implement robust Easy Apply click

### DIFF
--- a/modules/clickers_and_finders.py
+++ b/modules/clickers_and_finders.py
@@ -21,6 +21,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.common.exceptions import TimeoutException, ElementClickInterceptedException
 
 # Click Functions
 def wait_span_click(driver: WebDriver, text: str, time: float=5.0, click: bool=True, scroll: bool=True, scrollTop: bool=False) -> WebElement | bool:
@@ -182,3 +183,67 @@ def find_easy_apply_button(driver: WebDriver) -> WebElement | bool:
             scroll_to_view(driver, btn, True)
             return btn
     return False
+
+
+def click_easy_apply_button(driver: WebDriver) -> bool:
+    """Safely click the Easy Apply button if present."""
+    try:
+        container = driver.find_element(
+            By.CSS_SELECTOR, "div.job-details-jobs-unified-top-card__container--two-pane"
+        )
+        ea_button = container.find_element(
+            By.CSS_SELECTOR, "button.jobs-apply-button.artdeco-button--3"
+        )
+    except Exception:
+        return False
+
+    driver.execute_script(
+        "arguments[0].scrollIntoView({block:'center'});", container
+    )
+    driver.execute_script("window.scrollBy(0, -60);")
+    try:
+        ea_button.click()
+    except ElementClickInterceptedException:
+        try:
+            driver.execute_script("arguments[0].click()", ea_button)
+        except Exception:
+            return False
+    return True
+
+
+def click_easy_apply(
+    driver: WebDriver,
+    pagination_element: WebElement | None,
+    application_link: str,
+    tabs_count: int,
+) -> tuple[bool, str, int]:
+    """Click the external application button and switch to the new tab."""
+    try:
+        container = driver.find_element(
+            By.CSS_SELECTOR,
+            "div.job-details-jobs-unified-top-card__container--two-pane",
+        )
+        ea_button = container.find_element(
+            By.CSS_SELECTOR, "button.jobs-apply-button.artdeco-button--3"
+        )
+        driver.execute_script(
+            "arguments[0].scrollIntoView({block:'center'});", container
+        )
+        driver.execute_script("window.scrollBy(0, -60);")
+        try:
+            ea_button.click()
+        except ElementClickInterceptedException:
+            driver.execute_script("arguments[0].click()", ea_button)
+
+        wait_span_click(driver, "Continue", 1, True, False)
+        windows = driver.window_handles
+        tabs_count = len(windows)
+        driver.switch_to.window(windows[-1])
+        application_link = driver.current_url
+        print_lg(f'Got the external application link "{application_link}"')
+        return False, application_link, tabs_count
+    except Exception:
+        print_lg("Easy Apply unavailable or couldn't be clicked")
+        if pagination_element is not None:
+            return True, application_link, tabs_count
+        return True, application_link, tabs_count

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -27,7 +27,13 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.common.exceptions import NoSuchElementException, ElementClickInterceptedException, NoSuchWindowException, ElementNotInteractableException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    ElementClickInterceptedException,
+    NoSuchWindowException,
+    ElementNotInteractableException,
+    TimeoutException,
+)
 
 from config.personals import *
 from config.questions import *
@@ -795,7 +801,7 @@ def external_apply(pagination_element: WebElement, job_id: str, job_link: str, r
     '''
     global tabs_count, dailyEasyApplyLimitReached
     if easy_apply_only:
-        message = ""
+        message = "External apply job skipped"
         try:
             notice = driver.find_element(By.CLASS_NAME, "artdeco-inline-feedback__message").text
             if "exceeded the daily application limit" in notice:
@@ -803,28 +809,41 @@ def external_apply(pagination_element: WebElement, job_id: str, job_link: str, r
                 message = "Daily application limit for Easy Apply is reached"
         except Exception:
             pass
-        if not message:
-            message = "Easy Apply unavailable or couldn't be clicked"
         print_lg(message)
-        if pagination_element != None: return True, application_link, tabs_count
-    try:
-        wait.until(EC.element_to_be_clickable((By.XPATH, ".//button[contains(@class,'jobs-apply-button') and contains(@class, 'artdeco-button--3')]"))).click() # './/button[contains(span, "Apply") and not(span[contains(@class, "disabled")])]'
-        wait_span_click(driver, "Continue", 1, True, False)
-        windows = driver.window_handles
-        tabs_count = len(windows)
-        driver.switch_to.window(windows[-1])
-        application_link = driver.current_url
-        print_lg('Got the external application link "{}"'.format(application_link))
-        if close_tabs and driver.current_window_handle != linkedIn_tab: driver.close()
-        driver.switch_to.window(linkedIn_tab)
-        return False, application_link, tabs_count
-    except Exception as e:
-        # print_lg(e)
+        failed_job(
+            job_id,
+            job_link,
+            resume,
+            date_listed,
+            message,
+            "Skipped",
+            application_link,
+            screenshot_name,
+        )
+        global skip_count
+        skip_count += 1
+        if pagination_element != None:
+            return True, application_link, tabs_count
+    skip, application_link, tabs_count = click_easy_apply(driver, pagination_element, application_link, tabs_count)
+    if skip:
         print_lg("Failed to apply!")
-        failed_job(job_id, job_link, resume, date_listed, "Probably didn't find Apply button or unable to switch tabs.", e, application_link, screenshot_name)
+        failed_job(
+            job_id,
+            job_link,
+            resume,
+            date_listed,
+            "Probably didn't find Apply button or unable to switch tabs.",
+            "Click failed",
+            application_link,
+            screenshot_name,
+        )
         global failed_count
         failed_count += 1
-        return True, application_link, tabs_count
+    else:
+        if close_tabs and driver.current_window_handle != linkedIn_tab:
+            driver.close()
+        driver.switch_to.window(linkedIn_tab)
+    return skip, application_link, tabs_count
 
 
 
@@ -1049,18 +1068,20 @@ def apply_to_jobs(search_terms: list[str]) -> None:
                     # Case 1: Easy Apply Button
                     easy_apply_button = find_easy_apply_button(driver)
                     if easy_apply_button:
-                        try:
-                            easy_apply_button.click()
-                        except Exception as e:
-                            print_lg("Failed to click Easy Apply button", e)
-                            skip, application_link, tabs_count = external_apply(pagination_element, job_id, job_link, resume, date_listed, application_link, screenshot_name)
-                            if dailyEasyApplyLimitReached:
-                                print_lg("\n###############  Daily application limit for Easy Apply is reached!  ###############\n")
-                                return
-                            if skip:
-                                continue
-
-                        easy_apply_button.click()
+                        if not click_easy_apply_button(driver):
+                            print_lg("Easy Apply unavailable or couldn't be clicked")
+                            failed_job(
+                                job_id,
+                                job_link,
+                                resume,
+                                date_listed,
+                                "Easy Apply click failed",
+                                "Click failed",
+                                application_link,
+                                screenshot_name,
+                            )
+                            skip_count += 1
+                            continue
                         try: 
                             try:
                                 errored = ""


### PR DESCRIPTION
## Summary
- add `click_easy_apply_button` helper for reliably clicking Easy Apply
- use the helper in the main apply loop to avoid skipping jobs when the button is obstructed
- log skipped external jobs when easy-apply-only is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68435feb342083339c2532ba7b82b045