### PR TITLE
Refactor easy apply button logic

### DIFF
--- a/modules/clickers_and_finders.py
+++ b/modules/clickers_and_finders.py
@@ -184,30 +184,38 @@ def find_easy_apply_button(driver: WebDriver) -> WebElement | bool:
             return btn
     return False
 
-def click_easy_apply_button(driver: WebDriver) -> bool:
-    """Safely click the Easy Apply button if present."""
+def click_easy_apply_button(driver: WebDriver, button: WebElement | None = None) -> bool:
+    """Safely click the Easy Apply button if present.
+
+    Parameters
+    ----------
+    driver : WebDriver
+        Selenium driver instance.
+    button : WebElement | None, optional
+        If provided, this element will be used as the Easy Apply button.
+        Otherwise the function attempts to locate the button itself.
+    """
+
     try:
-        container = driver.find_element(
-            By.CSS_SELECTOR, "div.job-details-jobs-unified-top-card__container--two-pane"
+        if button is None:
+            container = driver.find_element(
+                By.CSS_SELECTOR, "div.job-details-jobs-unified-top-card__container--two-pane"
+            )
+            button = container.find_element(
+                By.CSS_SELECTOR, "button.jobs-apply-button.artdeco-button--3"
+            )
+        driver.execute_script(
+            "arguments[0].scrollIntoView({block:'center'});",
+            button,
         )
-        ea_button = container.find_element(
-            By.CSS_SELECTOR, "button.jobs-apply-button.artdeco-button--3"
-        )
+        driver.execute_script("window.scrollBy(0, -60);")
+        try:
+            button.click()
+        except ElementClickInterceptedException:
+            driver.execute_script("arguments[0].click()", button)
+        return True
     except Exception:
         return False
-
-    driver.execute_script(
-        "arguments[0].scrollIntoView({block:'center'});", container
-    )
-    driver.execute_script("window.scrollBy(0, -60);")
-    try:
-        ea_button.click()
-    except ElementClickInterceptedException:
-        try:
-            driver.execute_script("arguments[0].click()", ea_button)
-        except Exception:
-            return False
-    return True
 
 
 def click_easy_apply(

--- a/runAiBot.py
+++ b/runAiBot.py
@@ -983,6 +983,12 @@ def apply_to_jobs(search_terms: list[str]) -> None:
                     questions_list = None
                     screenshot_name = "Not Available"
 
+                    # Locate the Easy Apply button once and pass it to the
+                    # click helper. This avoids searching for the element
+                    # multiple times within `click_easy_apply_button`.
+                    easy_apply_btn = find_easy_apply_button(driver)
+                    click_easy_apply_button(driver, easy_apply_btn)
+
                     try:
                         rejected_jobs, blacklisted_companies, jobs_top_card = check_blacklist(rejected_jobs,job_id,company,blacklisted_companies)
                     except ValueError as e:

--- a/tests/test_click_easy_apply_button.py
+++ b/tests/test_click_easy_apply_button.py
@@ -29,3 +29,18 @@ def test_click_easy_apply_button_intercepted(monkeypatch):
 
     driver.execute_script.assert_any_call("arguments[0].click()", button)
     assert result is True
+
+
+def test_click_easy_apply_button_with_element(monkeypatch):
+    driver = MagicMock()
+    button = MagicMock()
+
+    # When passing the button directly the function should not try to
+    # locate it again and should still handle intercepted clicks.
+    button.click.side_effect = ElementClickInterceptedException()
+
+    result = click_easy_apply_button(driver, button)
+
+    driver.find_element.assert_not_called()
+    driver.execute_script.assert_any_call("arguments[0].click()", button)
+    assert result is True


### PR DESCRIPTION
## Summary
- support passing a pre-located Easy Apply button
- use the found button inside `apply_to_jobs`
- test both `click_easy_apply_button` code paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844a66916c883339b6c798906b8792d